### PR TITLE
Complete the GTK modules path

### DIFF
--- a/gnome/launcher-specific
+++ b/gnome/launcher-specific
@@ -11,6 +11,7 @@ if [ "$wayland_available" = true ]; then
   export QT_QPA_PLATFORM=wayland-egl
 fi
 append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-3.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-3.0"
 
 snap_python_version="%WITH_PYTHON%"
 if [ "$snap_python_version" = "3.6" ]; then


### PR DESCRIPTION
There are two places where the GTK3 modules can be installed, but the current code only contained one.

This MR adds the second one.