### PR TITLE
DT-486 Set libgweather Locations path

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -461,3 +461,6 @@ IBUS_CONFIG_PATH="$XDG_CONFIG_HOME/ibus"
 ensure_dir_exists "$IBUS_CONFIG_PATH"
 [ -d "$IBUS_CONFIG_PATH/bus" ] && rm -rf "$IBUS_CONFIG_PATH/bus"
 ln -sfn "$REALHOME/.config/ibus/bus" "$IBUS_CONFIG_PATH"
+
+# Set libgweather path
+export LIBGWEATHER_LOCATIONS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgweather-4/Locations.bin"


### PR DESCRIPTION
This MR sets a fixed path for libgweather, allowing it to be compiled in the Gnome SDK. The MR https://github.com/ubuntu/gnome-sdk/pull/62 requires this in order to work.