### PR TITLE
DT-500 Fix printing in gnome-text-editor

### DIFF
--- a/gnome/launcher-specific
+++ b/gnome/launcher-specific
@@ -10,8 +10,12 @@ if [ "$wayland_available" = true ]; then
   # Does not hurt to specify this as well, just in case
   export QT_QPA_PLATFORM=wayland-egl
 fi
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-2.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-2.0"
 append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-3.0"
 append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-3.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gtk-4.0"
+append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-4.0"
 
 snap_python_version="%WITH_PYTHON%"
 if [ "$snap_python_version" = "3.6" ]; then


### PR DESCRIPTION
Gnome-text-editor crashed when trying to print. This is because
Gtk can't find the modules. The first patch binded the modules
folder into the root, but James commented that it could be
fixed just with an environment variable.

This patch sets that variable for both GTK4 and GTK2, which
were both missing (it was set only for GTK3).