### PR TITLE
Add python 3.10 support to PYTHONPATH setup

### DIFF
--- a/gnome/launcher-specific
+++ b/gnome/launcher-specific
@@ -16,8 +16,8 @@ append_dir GTK_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/gtk-3.0"
 snap_python_version="%WITH_PYTHON%"
 if [ "$snap_python_version" = "3.6" ]; then
   append_dir PYTHONPATH "$SNAP_DESKTOP_RUNTIME/usr/lib/python3.6/site-packages"
-elif [ "$snap_python_version" = "3.8" ]; then
-  append_dir PYTHONPATH "$SNAP_DESKTOP_RUNTIME/usr/lib/python3.8"
+else # python version is 3.8 or higher.
+  append_dir PYTHONPATH "$SNAP_DESKTOP_RUNTIME/usr/lib/python$snap_python_version"
 fi
 append_dir PYTHONPATH "$SNAP_DESKTOP_RUNTIME/usr/lib/python3/dist-packages"
 


### PR DESCRIPTION
Only special-case `PYTHONPATH` for Python 3.6. For any other Python version we will assume that it is version 3.8 or higher and set the `PYTHONPATH` accordingly.