### PR TITLE
Bug 1796939 - Set libthai dictionary path for Firefox and others

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -472,3 +472,6 @@ ln -sfn "$REALHOME/.config/ibus/bus" "$IBUS_CONFIG_PATH"
 
 # Set libgweather path
 export LIBGWEATHER_LOCATIONS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgweather-4/Locations.bin"
+
+# Set libthai dict path
+export LIBTHAI_DICTDIR="$SNAP_DESKTOP_RUNTIME/usr/share/libthai/"


### PR DESCRIPTION
The fix was included as https://github.com/snapcore/snapcraft/pull/4170 but that isn't the right place