### PR TITLE
Update launcher scripts to reflect new file paths

### DIFF
--- a/qt-framework/launcher-specific
+++ b/qt-framework/launcher-specific
@@ -3,29 +3,34 @@
 # QT Framework launcher specific part #
 #######################################
 
+if [ -d $SNAP_DESKTOP_RUNTIME/usr/include/$ARCH/qt5 ] 
+then
+    export QT_SELECT=5
+else
+    export QT_SELECT=6
+fi
+
 # Add paths for games
 append_dir PATH "$SNAP/usr/games"
 append_dir PATH "$SNAP_DESKTOP_RUNTIME/usr/games"
 
 # Qt Libs
-for d in $SNAP_DESKTOP_RUNTIME/opt/*; do prepend_dir LD_LIBRARY_PATH "$d/lib"; done
+append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH"
 append_dir LD_LIBRARY_PATH "$SNAP/usr/lib/$ARCH"
 
 # Add QT_PLUGIN_PATH (Qt Modules).
-for d in $SNAP_DESKTOP_RUNTIME/opt/*; do prepend_dir QT_PLUGIN_PATH "$d/plugins"; done
-append_dir QT_PLUGIN_PATH "$SNAP/usr/lib/$ARCH/qt6/plugins"
+append_dir QT_PLUGIN_PATH "$SNAP/usr/lib/$ARCH/qt$QT_SELECT/plugins"
 append_dir QT_PLUGIN_PATH "$SNAP/usr/lib/$ARCH"
-append_dir QT_PLUGIN_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt6/plugins"
+append_dir QT_PLUGIN_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/plugins"
 append_dir QT_PLUGIN_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/"
 # And QML2_IMPORT_PATH (Qt Modules).
-for d in $SNAP_DESKTOP_RUNTIME/opt/*; do prepend_dir QML2_IMPORT_PATH "$d/qml"; done
-append_dir QML2_IMPORT_PATH "$SNAP/usr/lib/$ARCH/qt6/qml"
+append_dir QML2_IMPORT_PATH "$SNAP/usr/lib/$ARCH/qt$QT_SELECT/qml"
 append_dir QML2_IMPORT_PATH "$SNAP/lib/$ARCH"
-append_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt6/qml"
+append_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/qml"
 append_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/lib/$ARCH"
 
 # Fix locating the QtWebEngineProcess executable
-export QTWEBENGINEPROCESS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt6/libexec/QtWebEngineProcess"
+append_dir QTWEBENGINEPROCESS_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/libexec/QtWebEngineProcess"
 
 # Removes Qt warning: Could not find a location
 # of the system Compose files
@@ -36,14 +41,15 @@ export QT_XKB_CONFIG_ROOT="/usr/share/X11/xkb"
 export QTCHOOSER_NO_GLOBAL_DIR=1
 # qtchooser hardcodes reference paths, we'll need to rewrite them properly
 ensure_dir_exists "$XDG_CONFIG_HOME/qtchooser"
-echo "$SNAP/usr/lib/qt6/bin" > "$XDG_CONFIG_HOME/qtchooser/6.conf"
-echo "$SNAP/usr/lib/$ARCH" >> "$XDG_CONFIG_HOME/qtchooser/6.conf"
-find $SNAP_DESKTOP_RUNTIME/opt/ -maxdepth 1 -mindepth 1 -type d -exec bash -c 'echo "{}/bin" >> "$XDG_CONFIG_HOME/qtchooser/6.conf"' \;
-find $SNAP_DESKTOP_RUNTIME/opt/ -maxdepth 1 -mindepth 1 -type d -exec bash -c 'echo "{}/lib" >> "$XDG_CONFIG_HOME/qtchooser/6.conf"' \;
-echo "$SNAP/usr/lib/qt6/bin" > "$XDG_CONFIG_HOME/qtchooser/default.conf"
+echo "$SNAP/usr/lib/qt$QT_SELECT/bin" > "$XDG_CONFIG_HOME/qtchooser/$QT_SELECT.conf"
+echo "$SNAP/usr/lib/$ARCH" >> "$XDG_CONFIG_HOME/qtchooser/$QT_SELECT.conf"
+echo "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/bin" >> "$XDG_CONFIG_HOME/qtchooser/$QT_SELECT.conf"
+echo "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/lib" >> "$XDG_CONFIG_HOME/qtchooser/$QT_SELECT.conf"
+
+echo "$SNAP/usr/lib/qt$QT_SELECT/bin" > "$XDG_CONFIG_HOME/qtchooser/default.conf"
 echo "$SNAP/usr/lib/$ARCH" >> "$XDG_CONFIG_HOME/qtchooser/default.conf"
-find $SNAP_DESKTOP_RUNTIME/opt/ -maxdepth 1 -mindepth 1 -type d -exec bash -c 'echo "{}/bin" >> "$XDG_CONFIG_HOME/qtchooser/default.conf"' \;
-find $SNAP_DESKTOP_RUNTIME/opt/ -maxdepth 1 -mindepth 1 -type d -exec bash -c 'echo "{}/lib" >> "$XDG_CONFIG_HOME/qtchooser/default.conf"' \;
+echo "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/bin" >> "$XDG_CONFIG_HOME/qtchooser/default.conf"
+echo "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/lib" >> "$XDG_CONFIG_HOME/qtchooser/default.conf"
 
 # This relies on qtbase patch
 # 0001-let-qlibraryinfo-fall-back-to-locate-qt.conf-via-XDG.patch
@@ -53,8 +59,8 @@ find $SNAP_DESKTOP_RUNTIME/opt/ -maxdepth 1 -mindepth 1 -type d -exec bash -c 'e
 # is QtWebEngine which will not work unless the Data path is correctly set.
 cat << EOF > "$XDG_CONFIG_HOME/qt.conf"
 [Paths]
-Data = $SNAP_DESKTOP_RUNTIME/usr/share/qt6/
-Translations = $SNAP_DESKTOP_RUNTIME/usr/share/qt6/translations
+Data = $SNAP_DESKTOP_RUNTIME/usr/share/qt$QT_SELECT/
+Translations = $SNAP_DESKTOP_RUNTIME/usr/share/qt$QT_SELECT/translations
 EOF
 
 if [ -e "$SNAP_DESKTOP_RUNTIME/usr/share/i18n" ]; then

--- a/qt-framework/launcher-specific
+++ b/qt-framework/launcher-specific
@@ -15,19 +15,19 @@ append_dir PATH "$SNAP/usr/games"
 append_dir PATH "$SNAP_DESKTOP_RUNTIME/usr/games"
 
 # Qt Libs
-append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH"
+prepend_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH"
 append_dir LD_LIBRARY_PATH "$SNAP/usr/lib/$ARCH"
 
 # Add QT_PLUGIN_PATH (Qt Modules).
 append_dir QT_PLUGIN_PATH "$SNAP/usr/lib/$ARCH/qt$QT_SELECT/plugins"
 append_dir QT_PLUGIN_PATH "$SNAP/usr/lib/$ARCH"
-append_dir QT_PLUGIN_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/plugins"
-append_dir QT_PLUGIN_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/"
+prepend_dir QT_PLUGIN_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/plugins"
+prepend_dir QT_PLUGIN_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/"
 # And QML2_IMPORT_PATH (Qt Modules).
 append_dir QML2_IMPORT_PATH "$SNAP/usr/lib/$ARCH/qt$QT_SELECT/qml"
 append_dir QML2_IMPORT_PATH "$SNAP/lib/$ARCH"
-append_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/qml"
-append_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/lib/$ARCH"
+prepend_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/qml"
+prepend_dir QML2_IMPORT_PATH "$SNAP_DESKTOP_RUNTIME/lib/$ARCH"
 
 # Fix locating the QtWebEngineProcess executable
 append_dir QTWEBENGINEPROCESS_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/qt$QT_SELECT/libexec/QtWebEngineProcess"


### PR DESCRIPTION
I am rebuilding the qt-framework snaps as individual snaps and therefore am moving the file paths to be more in line with what is in the debian packaging.  This PR reworks the launcher-specific script to configure it for those new paths.