### PR TITLE
Revert "Merge pull request #18 from snapcore/nvidia_egl_wayland"

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -124,9 +124,6 @@ append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pulseaudio"
 prepend_dir __EGL_VENDOR_LIBRARY_DIRS "/var/lib/snapd/lib/glvnd/egl_vendor.d"
 append_dir __EGL_VENDOR_LIBRARY_DIRS "$SNAP_DESKTOP_RUNTIME/usr/share/glvnd/egl_vendor.d"
 
-# EGL platform config dirs, needed for libnvidia-egl-wayland1
-append_dir __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS "$SNAP_DESKTOP_RUNTIME/usr/share/egl/egl_external_platform.d"
-
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH="$SNAP/usr/lib/$ARCH/gstreamer-1.0"
 export GST_PLUGIN_SYSTEM_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer-1.0"


### PR DESCRIPTION
Revert "Merge pull request #18 from snapcore/nvidia_egl_wayland" which caused a regression

This reverts commit 6b9525354eff28e2f5e4aa8ca0ca0d0a3d257e9c, reversing changes made to 307a4787fa21a7a357485d5dd956c3accd53e327.