### PR TITLE
desktop-exports: point pipewire config and module dirs at the runtime

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -124,6 +124,11 @@ append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pulseaudio"
 prepend_dir __EGL_VENDOR_LIBRARY_DIRS "/var/lib/snapd/lib/glvnd/egl_vendor.d"
 append_dir __EGL_VENDOR_LIBRARY_DIRS "$SNAP_DESKTOP_RUNTIME/usr/share/glvnd/egl_vendor.d"
 
+# Tell Pipewire where to find its configuration and plugins
+export PIPEWIRE_CONFIG_DIR="$SNAP_DESKTOP_RUNTIME/usr/share/pipewire"
+export PIPEWIRE_MODULE_DIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/pipewire-0.3"
+export SPA_PLUGIN_DIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/spa-0.2"
+
 # Tell GStreamer where to find its plugins
 export GST_PLUGIN_PATH="$SNAP/usr/lib/$ARCH/gstreamer-1.0"
 export GST_PLUGIN_SYSTEM_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gstreamer-1.0"


### PR DESCRIPTION
To use libpipewire, it needs (a) access to its configuration files, and (b) access to it's modules, and (c) access to the SPA plugins.

I was a little surprised at (b), but debug logs do seem to show it looking for modules on the client side.