### PR TITLE
desktop-exports: fix checking XDG directory existence

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -211,9 +211,9 @@ if [ $needs_xdg_reload = true ]; then
   needs_xdg_reload=false
 fi
 
-# Check if we can actually read the contents of each xdg dir
+# Check existance of each xdg dir
 for ((i = 0; i < ${#XDG_SPECIAL_DIRS_PATHS[@]}; i++)); do
-  if ! can_open_file "${XDG_SPECIAL_DIRS_PATHS[$i]}"; then
+  if [ ! -d "${XDG_SPECIAL_DIRS_PATHS[$i]}" ]; then
     needs_xdg_update=true
     needs_xdg_links=true
     break


### PR DESCRIPTION
Hi,

While investigating start-up times of a snap using this desktop integration (used gnome-calculator as an example), I noticed 'xdg-user-dirs-update' is run at every launch. Even though nothing changed to any of those directories between launches.

I found the 'desktop-exports' script uses 'can_open_file()' to check for access to those XDG directories, at https://github.com/snapcore/snapcraft-desktop-integration/blob/main/common/desktop-exports#L216.
Given these are directories, this always fails and sets 'needs_xdg_update=true' (and also 'needs_xdg_links=true'). Which then triggers an invocation of 'xdg-user-dirs-update'.

Replacing the 'can_open_file()' check with a 'test -d', shows a +-230ms improvement on the RPi4 I am running this on.

Currently, fastest of 5 runs:
```
$ SNAP_DESKTOP_DEBUG=1 snap run gnome-calculator
desktop-launch elapsed time: 0.455134934
Now running: exec /snap/gnome-calculator/956/usr/bin/gnome-calculator
```

When applying this PR, fastest of 5 runs:
```
$ SNAP_DESKTOP_DEBUG=1 snap run gnome-calculator
desktop-launch elapsed time: 0.227555428
Now running: exec /snap/gnome-calculator/956/usr/bin/gnome-calculator
```

PS: 'can_open_file()' also checks for readability. I've omitted this check since 'xdg-user-dirs-update' accepts an XDG directory to not be readable.
