### PR TITLE
Fix libpxbackend not being found

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -492,3 +492,9 @@ export LIBGWEATHER_LOCATIONS_PATH="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libgweath
 
 # Set libthai dict path
 export LIBTHAI_DICTDIR="$SNAP_DESKTOP_RUNTIME/usr/share/libthai/"
+
+# Workaround for libproxy. It sets DT_RUNTIME to be able to find libpxbackend, which
+# isn't in the normal library path, but inside a folder. This works when the library
+# is in the default place, but not if it is snapped in the gnome-sdk/gnome-runtime snap.
+
+append_dir LD_LIBRARY_PATH "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/libproxy"


### PR DESCRIPTION
libpxbackend is installed at /usr/lib/x86_64-linux-gnu/libproxy, and libproxy sets that folder in DT_RUNTIME to be able to find it. Unfortunately, that only works when the library is installed in the standard place, not when it is in a snap (like it is the case with gnome-46-2404), so this change is required.

Fix https://forum.snapcraft.io/t/q-about-migration-to-core24-gnome-46/41100