### PR TITLE
Minor improvements to integration with GTK apps.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -471,7 +471,7 @@ fi
 
 # GTK theme and behavior modifier
 # Those can impact the theme engine used by Qt as well
-gtk_configs=(gtk-3.0/settings.ini gtk-3.0/gtk.css gtk-3.0/bookmarks gtk-2.0/gtkfilechooser.ini)
+gtk_configs=(gtk-4.0/settings.ini gtk-4.0/gtk.css gtk-4.0/bookmarks gtk-4.0/colors.css gtk-3.0/settings.ini gtk-3.0/gtk.css gtk-3.0/bookmarks gtk-3.0/colors.css gtk-2.0/gtkfilechooser.ini)
 for f in "${gtk_configs[@]}"; do
   dest="$XDG_CONFIG_HOME/$f"
   if [ ! -L "$dest" ]; then


### PR DESCRIPTION
I looked for this code elsewhere but couldn't find it, so I assume the gnome extension and the kde-neon-6 extension use this same code.

If I'm mistaken, I apologize and ask for the link to the correct file.

This change I made is a simple one, simply to improve Snap's integration with GTK apps and their themes, especially for KDE. The GTK Breeze theme defines its colors using the colors.css file. Without this change, GTK apps will appear incorrectly for KDE users, especially those who like to change the interface colors.