### PR TITLE
Minor improvements to integration with GTK apps

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -471,7 +471,7 @@ fi
 
 # GTK theme and behavior modifier
 # Those can impact the theme engine used by Qt as well
-gtk_configs=(gtk-3.0/settings.ini gtk-3.0/gtk.css gtk-3.0/bookmarks gtk-2.0/gtkfilechooser.ini)
+gtk_configs=(gtk-4.0/settings.ini gtk-4.0/gtk.css gtk-4.0/bookmarks gtk-4.0/colors.css gtk-3.0/settings.ini gtk-3.0/gtk.css gtk-3.0/bookmarks gtk-3.0/colors.css gtk-2.0/gtkfilechooser.ini)
 for f in "${gtk_configs[@]}"; do
   dest="$XDG_CONFIG_HOME/$f"
   if [ ! -L "$dest" ]; then


### PR DESCRIPTION
These changes are so that GTK apps can access more files from the gtk-3.0 folder, and can also access files from the gtk-4.0 folder.

This is also necessary so that the GTK Breeze theme in Snap apps can follow the colors that KDE is using.