### PR TITLE
Add no-sleep support for fc-cache

### DIFF
--- a/common/fonts
+++ b/common/fonts
@@ -40,6 +40,12 @@ EOF
 
 export FONTCONFIG_FILE="${SNAP_COMMON}/fontconfig/fonts.conf"
 
-"${SNAP_DESKTOP_RUNTIME}/usr/bin/fc-cache" --force --system-only --verbose || echo "configure hook: font generation failed"
+"${SNAP_DESKTOP_RUNTIME}/usr/bin/fc-cache" -h |grep no-sleep > /dev/null
+
+if [ $? -eq 0 ] ; then
+  "${SNAP_DESKTOP_RUNTIME}/usr/bin/fc-cache" --no-sleep --force --system-only --verbose || echo "configure hook: font generation failed"
+else
+  "${SNAP_DESKTOP_RUNTIME}/usr/bin/fc-cache" --force --system-only --verbose || echo "configure hook: font generation failed"
+fi
 
 exec "$@"


### PR DESCRIPTION
This patch allows to use the no-sleep option if available when using fc-cache. This removes the two-second delay during seeding.

https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2116949/