### PR TITLE
Add debug to fc-cache

### DIFF
--- a/common/fonts
+++ b/common/fonts
@@ -40,6 +40,10 @@ EOF
 
 export FONTCONFIG_FILE="${SNAP_COMMON}/fontconfig/fonts.conf"
 
-"${SNAP_DESKTOP_RUNTIME}/usr/bin/fc-cache" --force --system-only --verbose || echo "configure hook: font generation failed"
+systemd-cat -t "hook_$SNAP_NAME" echo "Launching fc-cache"
+
+systemd-cat -t "hook_$SNAP_NAME" "${SNAP_DESKTOP_RUNTIME}/usr/bin/fc-cache" --force --system-only --verbose || echo "configure hook: font generation failed"
+
+systemd-cat -t "hook_$SNAP_NAME" echo "Completed fc-cache"
 
 exec "$@"


### PR DESCRIPTION
This PR adds some debugging that sends messages to the systemd log, allowing to detect parts where the script is too slow.