### PR TITLE
Do not override GDK_PIXBUF_MODULE{DIR,_FILE}.

### DIFF
--- a/common/desktop-exports
+++ b/common/desktop-exports
@@ -436,8 +436,8 @@ append_dir LD_LIBRARY_PATH "$SNAP/testability/$ARCH"
 append_dir LD_LIBRARY_PATH "$SNAP/testability/$ARCH/mesa"
 
 # Gdk-pixbuf loaders
-export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
-export GDK_PIXBUF_MODULEDIR="$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
+export GDK_PIXBUF_MODULE_FILE=${GDK_PIXBUF_MODULE_FILE:-"$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"}
+export GDK_PIXBUF_MODULEDIR=${GDK_PIXBUF_MODULEDIR:-"$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"}
 if [ "$needs_update" = true ] || [ ! -f "$GDK_PIXBUF_MODULE_FILE" ]; then
   rm -f "$GDK_PIXBUF_MODULE_FILE"
   if [ -f "$SNAP_DESKTOP_RUNTIME/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" ]; then


### PR DESCRIPTION
This merge request is motivated by https://github.com/ubuntu/gnome-sdk/issues/357, where something is off in the Gnome runtime and one cannot point to the pixbuf staged in the end snap because it is always overriden.